### PR TITLE
Enforce log4j2 isn't used

### DIFF
--- a/plugin/trino-elasticsearch/pom.xml
+++ b/plugin/trino-elasticsearch/pom.xml
@@ -15,7 +15,6 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.log4j.version>2.13.3</dep.log4j.version>
         <dep.elasticsearch.version>6.0.0</dep.elasticsearch.version>
     </properties>
 
@@ -178,6 +177,10 @@
             <version>${dep.elasticsearch.version}</version>
             <exclusions>
                 <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.elasticsearch</groupId>
                     <artifactId>jna</artifactId>
                 </exclusion>
@@ -272,15 +275,8 @@
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>${dep.log4j.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>${dep.log4j.version}</version>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>2.15.0</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1628,6 +1628,12 @@
                                     <exclude>com.google.j2objc:j2objc-annotations</exclude>
                                 </excludes>
                             </requireUpperBoundDeps>
+                            <bannedDependencies>
+                                <excludes>
+                                    <!-- We don't use log4j2, additionally versions < 2.15.0 are vulnerable to the RCE Log4Shell (CVE-2021-44228) -->
+                                    <exclude>org.apache.logging.log4j:log4j-core</exclude>
+                                </excludes>
+                            </bannedDependencies>
                         </rules>
                     </configuration>
                     <dependencies>


### PR DESCRIPTION
We don't use log4j2 in Trino today.
Additionally versions older than 2.15.0 are vulnerable to a RCE
(CVE-2021-44228).