### PR TITLE
Alluxio properties configuration, AlluxioAccessStats and PatternBasedCacheFilter

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ parameters:
 jobs:
   - job: PrepareNode
     displayName: Prepare the node for the Container Build
-    pool: cauldron-vmss
+    pool: cybertron-build-pool
     steps:
       - checkout: none
       - bash: |
@@ -61,7 +61,7 @@ jobs:
         inputs:
           targetType: 'inline'
           script: |
-            MAVEN_OPTS="${{ variables.MAVEN_INSTALL_OPTS }}"
+            export MAVEN_OPTS="${{ variables.MAVEN_INSTALL_OPTS }}"
             $(Build.SourcesDirectory)/mvnw clean install ${{ variables.MAVEN_FAST_INSTALL }} -e -pl '${{ variables.SKIPPED_PROJECTS }}' -Dsmartbuilder.profiling=true -Dmaven.repo.local=${{ variables.m2RepoContainerPath }}
         condition: ne('${{ parameters.skipChecks }}', true)
       - task: Bash@3
@@ -69,7 +69,7 @@ jobs:
         inputs:
           targetType: 'inline'
           script: |
-            MAVEN_OPTS="${{ variables.MAVEN_INSTALL_OPTS }}"
+            export MAVEN_OPTS="${{ variables.MAVEN_INSTALL_OPTS }}"
             $(Build.SourcesDirectory)/mvnw clean install ${{ variables.MAVEN_FAST_INSTALL }} -Dair.check.skip-all -e -pl '${{ variables.SKIPPED_PROJECTS }}' -Dsmartbuilder.profiling=true -Dmaven.repo.local=${{ variables.m2RepoContainerPath }}
         condition: eq('${{ parameters.skipChecks }}', true)
       - task: Docker@2

--- a/cccs-build/Dockerfile
+++ b/cccs-build/Dockerfile
@@ -48,16 +48,16 @@ CMD [ "sleep", "infinity" ]
 ARG TRINO_VERSION
 LABEL cccs.trino.upstream.version=${TRINO_VERSION}
 
-# Install Maven 3.9.8
+# Install Maven 3.9.9
 RUN mkdir -p /tmp \
     # Install additional OS packages.
     && apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends bash-completion vim wget \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* \
-    # Download and install Maven 3.9.8 manually
-    && wget https://dlcdn.apache.org/maven/maven-3/3.9.8/binaries/apache-maven-3.9.8-bin.tar.gz -P /tmp \
-    && tar xzvf /tmp/apache-maven-3.9.8-bin.tar.gz -C /opt \
-    && ln -s /opt/apache-maven-3.9.8/bin/mvn /usr/bin/mvn \
+    # Download and install Maven 3.9.9 manually
+    && wget https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz -P /tmp \
+    && tar xzvf /tmp/apache-maven-3.9.9-bin.tar.gz -C /opt \
+    && ln -s /opt/apache-maven-3.9.9/bin/mvn /usr/bin/mvn \
     # Install Trino CLI
     && wget https://repo1.maven.org/maven2/io/trino/trino-cli/${TRINO_VERSION}/trino-cli-${TRINO_VERSION}-executable.jar -P /usr/local/bin \
     && chmod +x /usr/local/bin/trino-cli-${TRINO_VERSION}-executable.jar \

--- a/core/trino-web-ui/src/main/resources/webapp/src/package.json
+++ b/core/trino-web-ui/src/main/resources/webapp/src/package.json
@@ -35,8 +35,8 @@
     "package:clean": "npm clean-install && webpack --config webpack.config.js",
     "watch": "npm clean-install && webpack --config webpack.config.js --watch",
     "flow": "flow",
-    "check": "npm install && flow && prettier --check **/*.js **/*.jsx *.js *.jsx",
-    "check:clean": "npm clean-install && flow && prettier --check **/*.js **/*.jsx *.js *.jsx",
+    "check": "npm install && prettier --check **/*.js **/*.jsx *.js *.jsx",
+    "check:clean": "npm clean-install && prettier --check **/*.js **/*.jsx *.js *.jsx",
     "format": "prettier --write **/*.js **/*.jsx *.js *.jsx",
     "lint": "prettier --check **/*.js **/*.jsx"
   }

--- a/lib/trino-filesystem-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemFactory.java
+++ b/lib/trino-filesystem-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemFactory.java
@@ -16,33 +16,32 @@ package io.trino.filesystem.alluxio;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.Configuration;
 import com.google.inject.Inject;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.spi.security.ConnectorIdentity;
 
+import static java.util.Objects.requireNonNull;
+
 public class AlluxioFileSystemFactory
         implements TrinoFileSystemFactory
 {
-    private final AlluxioConfiguration conf;
+    private final FileSystem client;
 
     @Inject
-    public AlluxioFileSystemFactory()
+    public AlluxioFileSystemFactory(FileSystem client)
     {
-        this(Configuration.global());
+        this.client = requireNonNull(client, "client is null");
     }
 
     public AlluxioFileSystemFactory(AlluxioConfiguration conf)
     {
-        this.conf = conf;
+        this(FileSystem.Factory.create(FileSystemContext.create(requireNonNull(conf, "conf is null"))));
     }
 
     @Override
     public TrinoFileSystem create(ConnectorIdentity identity)
     {
-        FileSystemContext fsContext = FileSystemContext.create(conf);
-        FileSystem alluxioClient = FileSystem.Factory.create(fsContext);
-        return new AlluxioFileSystem(alluxioClient);
+        return new AlluxioFileSystem(client);
     }
 }

--- a/lib/trino-filesystem-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemModule.java
+++ b/lib/trino-filesystem-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemModule.java
@@ -13,8 +13,13 @@
  */
 package io.trino.filesystem.alluxio;
 
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
+import alluxio.conf.Configuration;
 import com.google.inject.Binder;
 import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
 
 import static com.google.inject.Scopes.SINGLETON;
 
@@ -25,5 +30,13 @@ public class AlluxioFileSystemModule
     public void configure(Binder binder)
     {
         binder.bind(AlluxioFileSystemFactory.class).in(SINGLETON);
+    }
+
+    @Provides
+    @Singleton
+    public FileSystem createAlluxioFileSystem()
+    {
+        FileSystemContext fsContext = FileSystemContext.create(Configuration.global());
+        return FileSystem.Factory.create(fsContext);
     }
 }

--- a/lib/trino-filesystem-cache-alluxio/pom.xml
+++ b/lib/trino-filesystem-cache-alluxio/pom.xml
@@ -18,6 +18,21 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
         </dependency>
@@ -40,7 +55,17 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
         </dependency>
 
         <dependency>

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioAccessStats.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioAccessStats.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.airlift.log.Logger;
+import io.trino.filesystem.Location;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Collectors;
+
+public class AlluxioAccessStats
+        implements Runnable
+{
+    private static final Logger log = Logger.get(AlluxioAccessStats.class);
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private final ConcurrentHashMap<String, Stats> externalReads = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Stats> cacheReads = new ConcurrentHashMap<>();
+
+    private static class Stats
+    {
+        final LongAdder hits = new LongAdder();
+        final LongAdder bytes = new LongAdder();
+
+        void add(int byteCount)
+        {
+            hits.increment();
+            bytes.add(byteCount);
+        }
+
+        Map<String, Long> toMap()
+        {
+            return Map.of(
+                "hits", hits.sum(),
+                "bytes", bytes.sum());
+        }
+    }
+
+    /**
+     * Normalizes a given file path to the table-level path for statistics aggregation.
+     * <p>
+     * This method trims the path at the first occurrence of either "/data/" or "/metadata/"
+     * so that reads are aggregated at the table level instead of per individual file.
+     * For example:
+     * <pre>
+     * abfss://warehouse@storageaccount.dfs.core.windows.net/iceberg/schema/table/data/00001.parquet
+     *   becomes
+     * abfss://warehouse@storageaccount.dfs.core.windows.net/iceberg/schema/table
+     * </pre>
+     *
+     * @param path the full path of a file or metadata
+     * @return the normalized table-level path
+     */
+    private String normalizePath(String path)
+    {
+        int dataIdx = path.indexOf("/data/");
+        int metadataIdx = path.indexOf("/metadata/");
+
+        int idx = -1;
+        if (dataIdx > 0 && metadataIdx > 0) {
+            idx = Math.min(dataIdx, metadataIdx);
+        }
+        else if (dataIdx > 0) {
+            idx = dataIdx;
+        }
+        else if (metadataIdx > 0) {
+            idx = metadataIdx;
+        }
+
+        if (idx > 0) {
+            return path.substring(0, idx);
+        }
+
+        return path;
+    }
+
+    public void recordExternalRead(int bytes, Location location)
+    {
+        if (bytes > 0) {
+            log.debug("External read: %s bytes for %s", bytes, location);
+            externalReads.computeIfAbsent(normalizePath(location.toString()), p -> new Stats()).add(bytes);
+        }
+    }
+
+    public void recordCacheRead(int bytes, Location location)
+    {
+        if (bytes > 0) {
+            log.debug("Cache read: %s bytes for %s", bytes, location);
+            cacheReads.computeIfAbsent(normalizePath(location.toString()), p -> new Stats()).add(bytes);
+        }
+    }
+
+    @Override
+    public void run()
+    {
+        // Take snapshots and clear maps atomically to avoid race conditions
+        Map<String, Map<String, Long>> externalSnapshot = externalReads.entrySet().stream()
+                .collect(Collectors.toMap(
+                    Map.Entry::getKey,
+                    e -> e.getValue().toMap()));
+        externalReads.clear();
+
+        Map<String, Map<String, Long>> cacheSnapshot = cacheReads.entrySet().stream()
+                .collect(Collectors.toMap(
+                    Map.Entry::getKey,
+                    e -> e.getValue().toMap()));
+        cacheReads.clear();
+
+        // Skip logging if both are empty
+        if (externalSnapshot.isEmpty() && cacheSnapshot.isEmpty()) {
+            return;
+        }
+
+        Map<String, Object> output = Map.of(
+                "externalReads", externalSnapshot,
+                "cacheReads", cacheSnapshot);
+
+        try {
+            String json = mapper.writeValueAsString(output);
+            log.info("AlluxioAccessStats=" + json);
+        }
+        catch (JsonProcessingException e) {
+            log.error("Failed to serialize AlluxioAccessStats", e);
+        }
+    }
+}

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioConfigurationFactory.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioConfigurationFactory.java
@@ -16,15 +16,19 @@ package io.trino.filesystem.alluxio;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.AlluxioProperties;
 import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import static alluxio.conf.PropertyKey.USER_CLIENT_CACHE_DIRS;
@@ -42,6 +46,9 @@ import static java.lang.String.join;
 
 public class AlluxioConfigurationFactory
 {
+    private static final Logger log = Logger.get(AlluxioConfigurationFactory.class);
+    private static final Path CONFIG_PATH = Path.of("/opt/alluxio/conf/alluxio-site.properties");
+
     private AlluxioConfigurationFactory() {}
 
     public static AlluxioConfiguration create(AlluxioFileSystemCacheConfig config)
@@ -67,6 +74,7 @@ public class AlluxioConfigurationFactory
             alluxioProperties.set(USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS, ttl.orElseThrow().roundTo(TimeUnit.SECONDS));
             alluxioProperties.set(USER_CLIENT_CACHE_TTL_ENABLED, true);
         }
+        loadFromSiteProperties(alluxioProperties);
         return new InstancedConfiguration(alluxioProperties);
     }
 
@@ -100,5 +108,35 @@ public class AlluxioConfigurationFactory
             maxCacheSizes.add(DataSize.of(Math.round(cachePercentages.get(i) / 100.0 * cacheDiskSizes.get(i)), DataSize.Unit.BYTE));
         }
         return maxCacheSizes.build();
+    }
+
+    private static void loadFromSiteProperties(AlluxioProperties alluxioProperties)
+    {
+        if (Files.isRegularFile(CONFIG_PATH)) {
+            try (var reader = Files.newBufferedReader(CONFIG_PATH)) {
+                Properties siteProps = new Properties();
+                siteProps.load(reader);
+                for (var entry : siteProps.entrySet()) {
+                    String key = entry.getKey().toString();
+                    String value = entry.getValue().toString();
+                    try {
+                        PropertyKey propertyKey = PropertyKey.fromString(key);
+                        alluxioProperties.set(propertyKey, value);
+                        log.info("Set Alluxio property: %s = %s", key, value);
+                    }
+                    catch (IllegalArgumentException e) {
+                        log.warn("Skipping unknown Alluxio property: %s", key, e);
+                    }
+                }
+
+                log.debug("AlluxioProperties after loading:");
+                alluxioProperties.forEach((key, value) -> {
+                    log.debug("Property: %s = %s", key.getName(), value);
+                });
+            }
+            catch (IOException e) {
+                throw new RuntimeException("Failed to load alluxio-site.properties", e);
+            }
+        }
     }
 }

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCache.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCache.java
@@ -16,13 +16,16 @@ package io.trino.filesystem.alluxio;
 import alluxio.client.file.CacheContext;
 import alluxio.client.file.URIStatus;
 import alluxio.client.file.cache.CacheManager;
+import alluxio.client.file.cache.filter.CacheFilter;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.wire.FileInfo;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.google.inject.Inject;
+import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import io.opentelemetry.api.trace.Tracer;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoInput;
@@ -33,43 +36,77 @@ import jakarta.annotation.PreDestroy;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 public class AlluxioFileSystemCache
         implements TrinoFileSystemCache
 {
+    private static final Logger log = Logger.get(AlluxioFileSystemCache.class);
+
     private final Tracer tracer;
     private final DataSize pageSize;
     private final CacheManager cacheManager;
+    private final CacheFilter cacheFilter;
     private final AlluxioConfiguration config;
     private final AlluxioCacheStats statistics;
+    private final AlluxioAccessStats accessStatistics;
+    private final ScheduledThreadPoolExecutor accessStatisticsExecutor = new ScheduledThreadPoolExecutor(1, daemonThreadsNamed("alluxio-access-stats"));
     private final HashFunction hashFunction = Hashing.murmur3_128();
 
     @Inject
-    public AlluxioFileSystemCache(Tracer tracer, AlluxioFileSystemCacheConfig config, AlluxioCacheStats statistics)
+    public AlluxioFileSystemCache(Tracer tracer, AlluxioFileSystemCacheConfig config, AlluxioCacheStats statistics, AlluxioAccessStats accessStatistics)
             throws IOException
     {
         this.tracer = requireNonNull(tracer, "tracer is null");
         this.config = AlluxioConfigurationFactory.create(requireNonNull(config, "config is null"));
         this.pageSize = config.getCachePageSize();
         this.cacheManager = CacheManager.Factory.create(this.config);
+        this.cacheFilter = CacheFilter.create(this.config);
         this.statistics = requireNonNull(statistics, "statistics is null");
+        this.accessStatistics = requireNonNull(accessStatistics, "accessStatistics is null");
+        Optional<Duration> accessStatsLogInterval = config.getAccessStatsLogInterval();
+        this.accessStatisticsExecutor.scheduleWithFixedDelay(() -> {
+            try {
+                accessStatistics.run();
+            }
+            catch (Throwable e) {
+                log.error(e, "Error running AlluxioAccessStats");
+            }
+        }, 0, accessStatsLogInterval.orElseThrow().roundTo(TimeUnit.SECONDS), TimeUnit.SECONDS);
     }
 
     @Override
     public TrinoInput cacheInput(TrinoInputFile delegate, String key)
             throws IOException
     {
-        return new AlluxioInput(tracer, delegate, key, uriStatus(delegate, key), new TracingCacheManager(tracer, key, pageSize, cacheManager), config, statistics);
+        URIStatus status = uriStatus(delegate, key);
+        boolean skipCache = !cacheFilter.needsCache(status);
+
+        if (skipCache) {
+            log.debug("Skipping caching for input: %s", status.getPath());
+        }
+
+        return new AlluxioInput(tracer, delegate, key, status, new TracingCacheManager(tracer, key, pageSize, cacheManager), config, statistics, accessStatistics, skipCache);
     }
 
     @Override
     public TrinoInputStream cacheStream(TrinoInputFile delegate, String key)
             throws IOException
     {
-        return new AlluxioInputStream(tracer, delegate, key, uriStatus(delegate, key), new TracingCacheManager(tracer, key, pageSize, cacheManager), config, statistics);
+        URIStatus status = uriStatus(delegate, key);
+        boolean skipCache = !cacheFilter.needsCache(status);
+
+        if (skipCache) {
+            log.debug("Skipping caching for stream: %s", status.getPath());
+        }
+
+        return new AlluxioInputStream(tracer, delegate, key, status, new TracingCacheManager(tracer, key, pageSize, cacheManager), config, statistics, accessStatistics, skipCache);
     }
 
     @Override
@@ -96,6 +133,7 @@ public class AlluxioFileSystemCache
             throws Exception
     {
         cacheManager.close();
+        accessStatisticsExecutor.shutdownNow();
     }
 
     @VisibleForTesting

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCacheConfig.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCacheConfig.java
@@ -39,6 +39,7 @@ public class AlluxioFileSystemCacheConfig
     private Optional<Duration> cacheTTL = Optional.of(Duration.valueOf("7d"));
     private List<Integer> maxCacheDiskUsagePercentages = ImmutableList.of();
     private DataSize cachePageSize = DataSize.valueOf("1MB");
+    private Optional<Duration> accessStatsLogInterval = Optional.of(Duration.valueOf("5m"));
 
     @NotNull
     public List<String> getCacheDirectories()
@@ -113,6 +114,20 @@ public class AlluxioFileSystemCacheConfig
     public AlluxioFileSystemCacheConfig setCachePageSize(DataSize cachePageSize)
     {
         this.cachePageSize = cachePageSize;
+        return this;
+    }
+
+    @NotNull
+    public Optional<@MinDuration("10s") Duration> getAccessStatsLogInterval()
+    {
+        return accessStatsLogInterval;
+    }
+
+    @Config("fs.cache.access-stats-log-interval")
+    @ConfigDescription("Interval at which table-level path statistics are logged.")
+    public AlluxioFileSystemCacheConfig setAccessStatsLogInterval(Duration accessStatsLogInterval)
+    {
+        this.accessStatsLogInterval = Optional.of(accessStatsLogInterval);
         return this;
     }
 }

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCacheModule.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCacheModule.java
@@ -47,6 +47,7 @@ public class AlluxioFileSystemCacheModule
         configBinder(binder).bindConfig(AlluxioFileSystemCacheConfig.class);
         configBinder(binder).bindConfig(ConsistentHashingHostAddressProviderConfig.class);
         binder.bind(AlluxioCacheStats.class).in(SINGLETON);
+        binder.bind(AlluxioAccessStats.class).in(SINGLETON);
         Provider<CatalogName> catalogName = binder.getProvider(CatalogName.class);
         newExporter(binder).export(AlluxioCacheStats.class)
                 .as(generator -> generator.generatedNameOf(AlluxioCacheStats.class, catalogName.get().toString()));

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInput.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInput.java
@@ -33,6 +33,8 @@ public class AlluxioInput
     private final TrinoInputFile inputFile;
     private final long fileLength;
     private final AlluxioCacheStats statistics;
+    private final AlluxioAccessStats accessStatistics;
+    private final boolean skipCache;
     private final AlluxioInputHelper helper;
 
     private TrinoInput input;
@@ -45,12 +47,16 @@ public class AlluxioInput
             URIStatus status,
             CacheManager cacheManager,
             AlluxioConfiguration configuration,
-            AlluxioCacheStats statistics)
+            AlluxioCacheStats statistics,
+            AlluxioAccessStats accessStatistics,
+            boolean skipCache)
     {
         this.inputFile = requireNonNull(inputFile, "inputFile is null");
         this.fileLength = requireNonNull(status, "status is null").getLength();
         this.statistics = requireNonNull(statistics, "statistics is null");
-        this.helper = new AlluxioInputHelper(tracer, inputFile.location(), cacheKey, status, cacheManager, configuration, statistics);
+        this.accessStatistics = requireNonNull(accessStatistics, "accessStatistics is null");
+        this.skipCache = skipCache;
+        this.helper = new AlluxioInputHelper(tracer, inputFile.location(), cacheKey, status, cacheManager, configuration, statistics, accessStatistics);
     }
 
     @Override
@@ -66,7 +72,7 @@ public class AlluxioInput
             return;
         }
 
-        int bytesRead = helper.doCacheRead(position, buffer, offset, length);
+        int bytesRead = skipCache ? 0 : helper.doCacheRead(position, buffer, offset, length);
         if (length > bytesRead && position + bytesRead == fileLength) {
             throw new EOFException("Read %s of %s requested bytes: %s".formatted(bytesRead, length, inputFile.location()));
         }
@@ -83,9 +89,12 @@ public class AlluxioInput
         AlluxioInputHelper.PageAlignedRead aligned = helper.alignRead(position, length);
         byte[] readBuffer = new byte[aligned.length()];
         getInput().readFully(aligned.pageStart(), readBuffer, 0, readBuffer.length);
-        helper.putCache(aligned.pageStart(), aligned.pageEnd(), readBuffer, aligned.length());
+        if (!skipCache) {
+            helper.putCache(aligned.pageStart(), aligned.pageEnd(), readBuffer, aligned.length());
+        }
         System.arraycopy(readBuffer, aligned.pageOffset(), buffer, offset, length);
         statistics.recordExternalRead(readBuffer.length);
+        accessStatistics.recordExternalRead(readBuffer.length, inputFile.location());
         return length;
     }
 

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputHelper.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputHelper.java
@@ -48,6 +48,7 @@ public class AlluxioInputHelper
     private final String cacheKey;
     private final CacheManager cacheManager;
     private final AlluxioCacheStats statistics;
+    private final AlluxioAccessStats accessStatistics;
     private final Location location;
     private final int pageSize;
     private final long fileLength;
@@ -58,7 +59,7 @@ public class AlluxioInputHelper
     private long bufferStartPosition;
     private long bufferEndPosition;
 
-    public AlluxioInputHelper(Tracer tracer, Location location, String cacheKey, URIStatus status, CacheManager cacheManager, AlluxioConfiguration configuration, AlluxioCacheStats statistics)
+    public AlluxioInputHelper(Tracer tracer, Location location, String cacheKey, URIStatus status, CacheManager cacheManager, AlluxioConfiguration configuration, AlluxioCacheStats statistics, AlluxioAccessStats accessStatistics)
     {
         this.tracer = requireNonNull(tracer, "tracer is null");
         this.status = requireNonNull(status, "status is null");
@@ -67,6 +68,7 @@ public class AlluxioInputHelper
         this.cacheManager = requireNonNull(cacheManager, "cacheManager is null");
         this.pageSize = (int) requireNonNull(configuration, "configuration is null").getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE);
         this.statistics = requireNonNull(statistics, "statistics is null");
+        this.accessStatistics = requireNonNull(accessStatistics, "accessStatistics is null");
         this.location = requireNonNull(location, "location is null");
         // Buffer to reduce the cost of doing page aligned reads for small sequential reads pattern
         this.bufferSize = pageSize;
@@ -121,6 +123,7 @@ public class AlluxioInputHelper
         }
         int bytesRead = length - remainingLength;
         statistics.recordCacheRead(bytesRead);
+        accessStatistics.recordCacheRead(bytesRead, location);
         return bytesRead;
     }
 

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputStream.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputStream.java
@@ -48,6 +48,8 @@ public class AlluxioInputStream
     private final long fileLength;
     private final Location location;
     private final AlluxioCacheStats statistics;
+    private final AlluxioAccessStats accessStatistics;
+    private final boolean skipCache;
     private final String key;
     private final AlluxioInputHelper helper;
     private final Tracer tracer;
@@ -55,15 +57,17 @@ public class AlluxioInputStream
     private long position;
     private boolean closed;
 
-    public AlluxioInputStream(Tracer tracer, TrinoInputFile inputFile, String key, URIStatus status, CacheManager cacheManager, AlluxioConfiguration configuration, AlluxioCacheStats statistics)
+    public AlluxioInputStream(Tracer tracer, TrinoInputFile inputFile, String key, URIStatus status, CacheManager cacheManager, AlluxioConfiguration configuration, AlluxioCacheStats statistics, AlluxioAccessStats accessStatistics, boolean skipCache)
     {
         this.tracer = requireNonNull(tracer, "tracer is null");
         this.inputFile = requireNonNull(inputFile, "inputFile is null");
         this.fileLength = requireNonNull(status, "status is null").getLength();
         this.location = inputFile.location();
         this.statistics = requireNonNull(statistics, "statistics is null");
+        this.accessStatistics = requireNonNull(accessStatistics, "accessStatistics is null");
+        this.skipCache = skipCache;
         this.key = requireNonNull(key, "key is null");
-        this.helper = new AlluxioInputHelper(tracer, inputFile.location(), key, status, cacheManager, configuration, statistics);
+        this.helper = new AlluxioInputHelper(tracer, inputFile.location(), key, status, cacheManager, configuration, statistics, accessStatistics);
     }
 
     @Override
@@ -128,7 +132,7 @@ public class AlluxioInputStream
     private int doRead(byte[] bytes, int offset, int length)
             throws IOException
     {
-        int bytesRead = helper.doCacheRead(position, bytes, offset, length);
+        int bytesRead = skipCache ? 0 : helper.doCacheRead(position, bytes, offset, length);
         return addExact(bytesRead, doExternalRead0(position + bytesRead, bytes, offset + bytesRead, length - bytesRead));
     }
 
@@ -164,10 +168,13 @@ public class AlluxioInputStream
             throw new IOException("Unexpected end of stream");
         }
         verify(aligned.length() == externalBytesRead, "invalid number of external bytes read");
-        helper.putCache(aligned.pageStart(), aligned.pageEnd(), readBuffer, externalBytesRead);
+        if (!skipCache) {
+            helper.putCache(aligned.pageStart(), aligned.pageEnd(), readBuffer, externalBytesRead);
+        }
         int bytesToCopy = min(length, max(externalBytesRead - aligned.pageOffset(), 0));
         System.arraycopy(readBuffer, aligned.pageOffset(), buffer, offset, bytesToCopy);
         statistics.recordExternalRead(externalBytesRead);
+        accessStatistics.recordExternalRead(externalBytesRead, inputFile.location());
         return bytesToCopy;
     }
 

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/PatternBasedCacheFilter.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/PatternBasedCacheFilter.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import alluxio.client.file.URIStatus;
+import alluxio.client.file.cache.filter.CacheFilter;
+import alluxio.conf.AlluxioConfiguration;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import io.airlift.log.Logger;
+
+import java.io.BufferedReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+
+/**
+ * A cache filter that decides whether a path should be cached based on configured patterns.
+ * <p>
+ * This filter supports three modes via {@link FilterType}:
+ * <ul>
+ *     <li>{@code CACHE_ALL} - all paths are allowed to be cached.</li>
+ *     <li>{@code ALLOW_LIST} - only paths matching the configured regex patterns are allowed to be cached.</li>
+ *     <li>{@code BLOCK_LIST} - paths matching the configured regex patterns are blocked from caching.</li>
+ * </ul>
+ * <p>
+ * The filter is initialized from a JSON configuration file which must contain:
+ * <ul>
+ *     <li>{@code filterType} - one of {@code CACHE_ALL}, {@code ALLOW_LIST}, or {@code BLOCK_LIST}.</li>
+ *     <li>{@code regxPatternStrList} - a list of regex strings, required for ALLOW_LIST or BLOCK_LIST.</li>
+ * </ul>
+ */
+public class PatternBasedCacheFilter
+        implements CacheFilter
+{
+    private static final Logger log = Logger.get(PatternBasedCacheFilter.class);
+
+    public enum FilterType
+    {
+        CACHE_ALL,
+        ALLOW_LIST,
+        BLOCK_LIST
+    }
+
+    private final Path configPath;
+    private final ScheduledThreadPoolExecutor reloadConfigExecutor = new ScheduledThreadPoolExecutor(1, daemonThreadsNamed("reload-config"));
+    private volatile FilterType filterType;
+    private volatile List<Pattern> patterns;
+
+    /**
+     * Creates a {@code PatternBasedCacheFilter} based on a configuration file.
+     *
+     * @param conf the Alluxio configuration (not currently used for pattern evaluation)
+     * @param cacheConfigFile path to the JSON config file containing filterType and optional patterns
+     * @throws RuntimeException if the config file cannot be read or contains invalid configuration
+     */
+    public PatternBasedCacheFilter(AlluxioConfiguration conf, String cacheConfigFile)
+    {
+        log.debug("Initializing PatternBasedCacheFilter with config file: %s", cacheConfigFile);
+        this.configPath = Paths.get(cacheConfigFile);
+        this.reloadConfigExecutor.scheduleWithFixedDelay(this::reloadConfig, 0, 60, TimeUnit.SECONDS);
+    }
+
+    private void reloadConfig()
+    {
+        try {
+            try (BufferedReader reader = Files.newBufferedReader(configPath)) {
+                Map<String, Object> config = new Gson().fromJson(
+                        reader,
+                        new TypeToken<Map<String, Object>>() {}.getType());
+
+                String filterTypeStr = (String) config.get("filterType");
+                if (filterTypeStr == null) {
+                    throw new IllegalArgumentException("Missing 'filterType' in cache filter config.");
+                }
+
+                filterType = FilterType.valueOf(filterTypeStr.toUpperCase());
+
+                List<String> patternStrs = (List<String>) config.get("regxPatternStrList");
+
+                if (patternStrs == null) {
+                    patterns = Collections.emptyList();
+                }
+                else {
+                    patterns = patternStrs.stream()
+                        .map(Pattern::compile)
+                        .collect(Collectors.toList());
+                }
+
+                log.debug("Cache Filter initialized with filterType: %s", filterType);
+                if (!patterns.isEmpty()) {
+                    log.debug("Cache Filter regex patterns:");
+                    for (Pattern p : patterns) {
+                        log.debug("  - %s", p.pattern());
+                    }
+                }
+            }
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to initialize PatternBasedCacheFilter", e);
+        }
+    }
+
+    /**
+     * Determines whether the given path should be cached based on the filter type and patterns.
+     *
+     * @param uriStatus the path status to evaluate
+     * @return {@code true} if the path should be cached, {@code false} otherwise
+     * @throws IllegalStateException if the filter type is unsupported
+     */
+    @Override
+    public boolean needsCache(URIStatus uriStatus)
+    {
+        String path = uriStatus.getPath();
+
+        if (filterType == FilterType.CACHE_ALL) {
+            log.debug("CACHE_ALL enabled, using cache for path: %s", path);
+            return true;
+        }
+
+        boolean matches = patterns.stream().anyMatch(p -> p.matcher(path).matches());
+
+        switch (filterType) {
+            case ALLOW_LIST:
+                log.debug("ALLOW_LIST cache filter match for path %s: %s", path, matches);
+                return matches;
+            case BLOCK_LIST:
+                log.debug("BLOCK_LIST cache filter match for path %s: %s", path, matches);
+                return !matches;
+            default:
+                throw new IllegalStateException("Unsupported filter type: " + filterType);
+        }
+    }
+}

--- a/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioCacheFileSystem.java
+++ b/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioCacheFileSystem.java
@@ -55,7 +55,7 @@ public class TestAlluxioCacheFileSystem
                 .disableTTL()
                 .setMaxCacheSizes(ImmutableList.of(DataSize.valueOf("100MB")));
         memoryFileSystem = new IncompleteStreamMemoryFileSystem();
-        cache = new AlluxioFileSystemCache(noopTracer(), configuration, new AlluxioCacheStats());
+        cache = new AlluxioFileSystemCache(noopTracer(), configuration, new AlluxioCacheStats(), new AlluxioAccessStats());
         fileSystem = new CacheFileSystem(memoryFileSystem, cache, new DefaultCacheKeyProvider());
     }
 

--- a/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioCacheFileSystemAccessOperations.java
+++ b/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioCacheFileSystemAccessOperations.java
@@ -94,7 +94,7 @@ public class TestAlluxioCacheFileSystemAccessOperations
                 .setMaxCacheSizes(ImmutableList.of(DataSize.ofBytes(CACHE_SIZE)));
 
         tracingFileSystemFactory = new TracingFileSystemFactory(testingTelemetry.getTracer(), new MemoryFileSystemFactory());
-        alluxioCache = new AlluxioFileSystemCache(testingTelemetry.getTracer(), configuration, new AlluxioCacheStats());
+        alluxioCache = new AlluxioFileSystemCache(testingTelemetry.getTracer(), configuration, new AlluxioCacheStats(), new AlluxioAccessStats());
         fileSystem = new CacheFileSystem(tracingFileSystemFactory.create(ConnectorIdentity.ofUser("hello")), new TracingFileSystemCache(testingTelemetry.getTracer(), alluxioCache), cacheKeyProvider);
         pageStore = PageStore.create(Iterables.getOnlyElement(PageStoreOptions.create(AlluxioConfigurationFactory.create(configuration))));
     }

--- a/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestFuzzAlluxioCacheFileSystem.java
+++ b/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestFuzzAlluxioCacheFileSystem.java
@@ -183,7 +183,7 @@ public class TestFuzzAlluxioCacheFileSystem
                     .setCachePageSize(PAGE_SIZE)
                     .disableTTL()
                     .setMaxCacheSizes(ImmutableList.of(CACHE_SIZE));
-            AlluxioFileSystemCache alluxioCache = new AlluxioFileSystemCache(Tracing.noopTracer(), configuration, new AlluxioCacheStats());
+            AlluxioFileSystemCache alluxioCache = new AlluxioFileSystemCache(Tracing.noopTracer(), configuration, new AlluxioCacheStats(), new AlluxioAccessStats());
             return new CacheFileSystem(new IncompleteStreamMemoryFileSystem(), alluxioCache, new TestingCacheKeyProvider());
         }
 


### PR DESCRIPTION
Changes under trino/lib/trino-filesystem-alluxio/src/main/java/io/trino/filesystem/alluxio are just a fix back-ported from 477.

Otherwise I:
- Created AlluxioAccessStats to periodically log external reads vs cache reads to help us determine rules for the cache filter. I considered using JMX metrics for these but it's not really appropriate with a potentially infinite number of paths. Instead I just log to stdout in a format that I can work with to analyze the data.
- Created PatternBasedCacheFilter which is a simple filter that'll filter data in or out of the cache based on the configuration and the path of the data being read. The open-source Alluxio version used in Trino offers caching capabilities but doesn't offer an actual filter. They just allow everything through.
- Modified (almost exclusively by adding code - not actually modifying or removing) other Alluxio related classes to make use of AlluxioAccessStats, PatternBasedCacheFilter and allow the configuration of any Alluxio setting we want.

The AlluxioAccessStats will look something like this when logged:
```
{
  "cacheReads": {
    "abfss://warehouse@somestorageaccount.dfs.core.windows.net/iceberg/schema/table": {
      "bytes": 4306,
      "hits": 11
    }
  },
  "externalReads": {
    "abfss://warehouse@somestorageaccount.dfs.core.windows.net/iceberg/schema/table": {
      "bytes": 1157,
      "hits": 2
    }
  }
}
```
The workers and coordinator all have their own Alluxio cache and will log their stats separately. The configurable time to log the stats defaults to 5 minutes when the stats are logged and then wiped from memory.

Configuring the cache filter will look something like this:
```
{
  "filterType": "ALLOW_LIST",
  "regxPatternStrList": ["abfss://warehouse@somestorageaccount.dfs.core.windows.net/iceberg/schema/table.*"]
}
```
