### PR TITLE
Limit concurrent OPA authorization requests

### DIFF
--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaConfig.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaConfig.java
@@ -16,6 +16,7 @@ package io.trino.plugin.opa;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.validation.FileExists;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import java.net.URI;
@@ -34,6 +35,7 @@ public class OpaConfig
     private Optional<URI> opaColumnMaskingUri = Optional.empty();
     private Optional<URI> opaBatchColumnMaskingUri = Optional.empty();
     private Optional<Path> additionalContextFile = Optional.empty();
+    private int maxConcurrentRequests = 300;
 
     @NotNull
     public URI getOpaUri()
@@ -154,6 +156,20 @@ public class OpaConfig
     public OpaConfig setAdditionalContextFile(Path additionalContextFile)
     {
         this.additionalContextFile = Optional.ofNullable(additionalContextFile);
+        return this;
+    }
+
+    @Min(1)
+    public int getMaxConcurrentRequests()
+    {
+        return maxConcurrentRequests;
+    }
+
+    @Config("opa.max-concurrent-requests")
+    @ConfigDescription("Maximum number of concurrent HTTP requests sent to OPA")
+    public OpaConfig setMaxConcurrentRequests(int maxConcurrentRequests)
+    {
+        this.maxConcurrentRequests = maxConcurrentRequests;
         return this;
     }
 }

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaHttpClient.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaHttpClient.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.FluentFuture;
 import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.inject.Inject;

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaHttpClient.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaHttpClient.java
@@ -17,8 +17,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.FluentFuture;
+import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import com.google.inject.Inject;
 import io.airlift.http.client.FullJsonResponseHandler;
 import io.airlift.http.client.HttpClient;
@@ -37,13 +39,17 @@ import io.trino.spi.connector.ColumnSchema;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -51,6 +57,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.net.MediaType.JSON_UTF_8;
+import static com.google.common.util.concurrent.Futures.addCallback;
 import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
 import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
 import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
@@ -66,6 +73,7 @@ public class OpaHttpClient
     private final Executor executor;
     private final boolean logRequests;
     private final boolean logResponses;
+    private final int maxConcurrentRequests;
     private static final Logger log = Logger.get(OpaHttpClient.class);
 
     @Inject
@@ -80,6 +88,7 @@ public class OpaHttpClient
         this.executor = requireNonNull(executor, "executor is null");
         this.logRequests = config.getLogRequests();
         this.logResponses = config.getLogResponses();
+        this.maxConcurrentRequests = config.getMaxConcurrentRequests();
     }
 
     public <T> FluentFuture<T> submitOpaRequest(OpaQueryInput input, URI uri, JsonCodec<T> deserializer)
@@ -212,17 +221,71 @@ public class OpaHttpClient
         if (items.isEmpty()) {
             return ImmutableList.of();
         }
-        List<FluentFuture<Optional<X>>> allFutures = items.stream()
-                .map(item -> submitOpaRequest(requestBuilder.apply(item), uri, deserializer)
-                        .transform(result -> parser.apply(item, result), executor))
-                .collect(toImmutableList());
-        return consumeOpaResponse(
-                Futures.whenAllComplete(allFutures).call(
-                        () -> allFutures.stream()
-                                .map(this::consumeOpaResponse)
-                                .filter(Optional::isPresent)
-                                .map(Optional::get)
-                                .collect(toImmutableList()),
-                        executor));
+
+        log.debug("Submitting %d parallel OPA requests to %s with max concurrency %d", items.size(), uri, maxConcurrentRequests);
+
+        Iterator<T> iterator = items.iterator();
+        ConcurrentLinkedQueue<X> results = new ConcurrentLinkedQueue<>();
+        SettableFuture<List<X>> resultFuture = SettableFuture.create();
+        AtomicInteger remainingWorkers = new AtomicInteger(Math.min(maxConcurrentRequests, items.size()));
+        AtomicBoolean failed = new AtomicBoolean();
+
+        Object iteratorLock = new Object();
+
+        class Worker
+        {
+            void submitNext()
+            {
+                if (failed.get()) {
+                    return;
+                }
+
+                T item;
+                synchronized (iteratorLock) {
+                    if (!iterator.hasNext()) {
+                        if (remainingWorkers.decrementAndGet() == 0) {
+                            resultFuture.set(ImmutableList.copyOf(results));
+                        }
+                        return;
+                    }
+                    item = iterator.next();
+                }
+
+                FluentFuture<Optional<X>> future = submitOpaRequest(
+                        requestBuilder.apply(item),
+                        uri,
+                        deserializer)
+                        .transform(result -> parser.apply(item, result), executor);
+
+                addCallback(
+                        future,
+                        new FutureCallback<>()
+                        {
+                            @Override
+                            public void onSuccess(Optional<X> value)
+                            {
+                                value.ifPresent(results::add);
+                                submitNext();
+                            }
+
+                            @Override
+                            public void onFailure(Throwable throwable)
+                            {
+                                if (failed.compareAndSet(false, true)) {
+                                    resultFuture.setException(throwable);
+                                }
+                            }
+                        },
+                        executor);
+            }
+        }
+
+        Worker worker = new Worker();
+
+        for (int i = 0; i < remainingWorkers.get(); i++) {
+            worker.submitNext();
+        }
+
+        return consumeOpaResponse(resultFuture);
     }
 }


### PR DESCRIPTION
Previously, OpaHttpClient submitted all authorization requests immediately in parallel. Large metadata queries could generate thousands of requests, exhausting the HTTP client's per-destination queue and causing RejectedExecutionException.

opa.http-client.max-concurrent-requests binds the number of in-flight OPA requests while maintaining asynchronous execution.